### PR TITLE
Add GitHub Pages welcome site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Welcome</title>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Welcome to Winslowtest</h1>
+    <p>Start building your GitHub Pages site here.</p>
+  </div>
+</body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,25 @@
+body {
+  margin: 0;
+  font-family: 'Poppins', sans-serif;
+  background: linear-gradient(135deg, #ff9966, #66ccff);
+  color: #fff;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.container {
+  text-align: center;
+}
+
+h1 {
+  font-weight: 600;
+  font-size: 3em;
+  margin-bottom: 0.5em;
+}
+
+p {
+  font-weight: 300;
+  font-size: 1.25em;
+}


### PR DESCRIPTION
## Summary
- set up GitHub Pages root in `docs`
- add styled welcome page with gradient background

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d30f0bf7c8329846012a2b1616b7d