### PR TITLE
Revamp site with CNN-style layout

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,17 +1,67 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Welcome</title>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fake News Central</title>
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div class="container">
-    <h1>Welcome to Winslowtest</h1>
-    <p>Start building your GitHub Pages site here.</p>
-    <p><a href="tic-tac-toe.html">Play Tic-Tac-Toe</a></p>
-  </div>
+  <header class="top-bar">
+    <div class="logo">CNN Clone</div>
+    <nav class="nav-links">
+      <a href="#">World</a>
+      <a href="#">Politics</a>
+      <a href="#">Tech</a>
+      <a href="#">Health</a>
+      <a href="#">Sports</a>
+      <a href="tic-tac-toe.html">Tic Tac Toe</a>
+    </nav>
+  </header>
+
+  <main class="content">
+    <section class="featured">
+      <img src="https://picsum.photos/800/400?random=1" alt="Featured story image" />
+      <h2>Major Event Rocks The World</h2>
+      <p>
+        In a stunning turn of events, something unbelievable happened today. Experts are
+        baffled and the world is watching closely as more details unfold.
+      </p>
+    </section>
+
+    <section class="grid">
+      <article class="story">
+        <img src="https://picsum.photos/300/200?random=2" alt="Story image 1" />
+        <h3>Fake News Story 1</h3>
+        <p>Aliens land in Times Square demanding a meeting with Earth’s leaders.</p>
+      </article>
+      <article class="story">
+        <img src="https://picsum.photos/300/200?random=3" alt="Story image 2" />
+        <h3>Fake News Story 2</h3>
+        <p>Scientists discover coffee beans that can talk, sparking caffeine debates.</p>
+      </article>
+      <article class="story">
+        <img src="https://picsum.photos/300/200?random=4" alt="Story image 3" />
+        <h3>Fake News Story 3</h3>
+        <p>City installs trampoline sidewalks to make commuting more fun.</p>
+      </article>
+      <article class="story">
+        <img src="https://picsum.photos/300/200?random=5" alt="Story image 4" />
+        <h3>Fake News Story 4</h3>
+        <p>New smartphone app translates cat meows into human language.</p>
+      </article>
+      <article class="story">
+        <img src="https://picsum.photos/300/200?random=6" alt="Story image 5" />
+        <h3>Fake News Story 5</h3>
+        <p>Man breaks world record by eating 10,000 marshmallows in one sitting.</p>
+      </article>
+      <article class="story">
+        <img src="https://picsum.photos/300/200?random=7" alt="Story image 6" />
+        <h3>Fake News Story 6</h3>
+        <p>Robots form their own soccer league and demand equal rights.</p>
+      </article>
+    </section>
+  </main>
 </body>
 </html>
+

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,42 +1,75 @@
 body {
   margin: 0;
-  font-family: 'Poppins', sans-serif;
-  background: linear-gradient(135deg, #ff9966, #66ccff);
+  font-family: Helvetica, Arial, sans-serif;
+  background-color: #f2f2f2;
+  color: #000;
+}
+
+.top-bar {
+  background: #cc0000;
   color: #fff;
-  height: 100vh;
+  padding: 10px 20px;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
 }
 
-.container {
-  text-align: center;
+.logo {
+  font-weight: bold;
+  font-size: 1.5em;
 }
 
-h1 {
-  font-weight: 600;
-  font-size: 3em;
-  margin-bottom: 0.5em;
-}
-
-p {
-  font-weight: 300;
-  font-size: 1.25em;
-}
-
-a {
+.nav-links a {
   color: #fff;
+  margin-left: 15px;
   text-decoration: none;
-  font-weight: 600;
-  border: 2px solid #fff;
-  padding: 0.5em 1em;
-  border-radius: 8px;
-  display: inline-block;
-  margin-top: 1em;
-  transition: background 0.3s;
+  font-weight: bold;
 }
 
-a:hover {
-  background: rgba(255, 255, 255, 0.2);
+.nav-links a:hover {
+  text-decoration: underline;
+}
+
+.content {
+  max-width: 1200px;
+  margin: 20px auto;
+  padding: 0 20px;
+}
+
+.featured img {
+  width: 100%;
+  height: auto;
+}
+
+.featured h2 {
+  font-size: 2em;
+  margin: 0.5em 0;
+}
+
+.featured p {
+  font-size: 1.1em;
+  color: #333;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  grid-gap: 20px;
+  margin-top: 30px;
+}
+
+.story img {
+  width: 100%;
+  height: auto;
+}
+
+.story h3 {
+  font-size: 1.25em;
+  margin: 0.5em 0;
+}
+
+.story p {
+  color: #555;
+  font-size: 0.95em;
 }
 


### PR DESCRIPTION
## Summary
- Rebuild index page with CNN-style header and navigation
- Add placeholder fake news stories with images in a responsive grid
- Update CSS for red top bar and grid-based layout
- Add navigation link to 3D Tic Tac Toe game

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e32880ecc832983f4c901fdf5083b